### PR TITLE
Add PDF export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ This interactive HTML tool allows users to browse, filter, and select prompts ac
    - Use “Select All” or “Clear All” buttons in each section as needed.
    - The sidebar shows selected questions grouped by section and category.
 
-4. **Export Your Summary**  
-   - Use the “Export Word” or “Export PDF” buttons to save your selections.
+4. **Export Your Summary**
+   - Use the “Export Text,” “Export Word,” or “Export PDF” buttons to save your selections.
+   - The PDF option uses the lightweight `html2pdf.js` library to generate a PDF of the summary textbox.
 
 ## 💻 GitHub Deployment (Optional)
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <title>NASDDDS Prompt Selector</title>
   <!-- Link to the external stylesheet -->
   <link rel="stylesheet" href="style.css">
+  <!-- Library for exporting the summary to PDF -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
   <!-- Link to the external JavaScript file, deferred to load after the HTML -->
   <script src="script.js" defer></script>
 </head>
@@ -18,6 +20,7 @@
       <input type="text" id="filterInput" placeholder="Type to search…">
       <button id="exportTextBtn">Export Text</button>
       <button id="exportDocBtn">Export Word</button>
+      <button id="exportPdfBtn">Export PDF</button>
       <button id="clearAllGlobal">Clear All</button>
     </div>
   </div>

--- a/script.js
+++ b/script.js
@@ -207,6 +207,26 @@ function exportDoc() {
   URL.revokeObjectURL(a.href);
 }
 
+/**
+ * Exports the summary as a PDF file using html2pdf.js.
+ */
+function exportPdf() {
+  const text = document.getElementById('summary').value;
+  const container = document.createElement('div');
+  container.style.whiteSpace = 'pre-wrap';
+  container.textContent = text;
+
+  const opt = {
+    margin: 10,
+    filename: 'selected_questions.pdf',
+    image: { type: 'jpeg', quality: 0.98 },
+    html2canvas: { scale: 2 },
+    jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' }
+  };
+
+  html2pdf().set(opt).from(container).save();
+}
+
 // --- INITIALIZATION AND EVENT LISTENERS ---
 document.addEventListener('DOMContentLoaded', () => {
   loadAndRenderPrompts(); // Initial render
@@ -214,9 +234,10 @@ document.addEventListener('DOMContentLoaded', () => {
   // Attach listeners to static elements
   const filterInput = document.getElementById('filterInput');
   filterInput.addEventListener('input', () => renderUI(filterInput.value));
-  document.getElementById('exportTextBtn').addEventListener('click', exportText);
-  document.getElementById('exportDocBtn').addEventListener('click', exportDoc);
-  document.getElementById('clearAllGlobal').addEventListener('click', clearAllSelections);
+    document.getElementById('exportTextBtn').addEventListener('click', exportText);
+    document.getElementById('exportDocBtn').addEventListener('click', exportDoc);
+    document.getElementById('exportPdfBtn').addEventListener('click', exportPdf);
+    document.getElementById('clearAllGlobal').addEventListener('click', clearAllSelections);
 
   // Use event delegation for dynamically created elements
   const mainContent = document.getElementById('main-content');


### PR DESCRIPTION
## Summary
- add html2pdf library in the HTML
- provide a new Export PDF button
- implement `exportPdf()` in JavaScript
- wire up event listener for PDF export
- document PDF export usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bc84202088327921cd45d48855f4b