### PR TITLE
Add copy to clipboard feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
       <button id="exportTextBtn">Export Text</button>
       <button id="exportDocBtn">Export Word</button>
       <button id="exportPdfBtn">Export PDF</button>
+      <button id="copyBtn">Copy to Clipboard</button>
       <button id="clearAllGlobal">Clear All</button>
     </div>
   </div>

--- a/script.js
+++ b/script.js
@@ -236,6 +236,16 @@ function exportPdf() {
   html2pdf().set(opt).from(container).save();
 }
 
+/**
+ * Copies the summary text to the clipboard.
+ */
+function copySummary() {
+  const text = document.getElementById('summary').value;
+  navigator.clipboard.writeText(text).catch(err => {
+    console.error('Failed to copy summary', err);
+  });
+}
+
 // --- INITIALIZATION AND EVENT LISTENERS ---
 document.addEventListener('DOMContentLoaded', () => {
   const stored = localStorage.getItem('selectedQuestions');
@@ -254,6 +264,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('exportTextBtn').addEventListener('click', exportText);
     document.getElementById('exportDocBtn').addEventListener('click', exportDoc);
     document.getElementById('exportPdfBtn').addEventListener('click', exportPdf);
+    document.getElementById('copyBtn').addEventListener('click', copySummary);
     document.getElementById('clearAllGlobal').addEventListener('click', clearAllSelections);
 
   // Use event delegation for dynamically created elements

--- a/style.css
+++ b/style.css
@@ -55,8 +55,14 @@ button {
   cursor: pointer; 
   transition: background-color 0.2s;
 }
-button:hover { 
-  background: #004466; 
+button:hover {
+  background: #004466;
+}
+
+/* Copy button styling matches other control buttons */
+#copyBtn {
+  background: #006699;
+  color: #fff;
 }
 
 /* Main Layout: Main Content and Sidebar */


### PR DESCRIPTION
## Summary
- add a *Copy to Clipboard* button to the topbar controls
- implement `copySummary()` in JavaScript
- style the copy button so it matches the existing controls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bdae6c2dc83278c4bb0a7aece6567